### PR TITLE
feat: sort and filter weight progress chart logs by date

### DIFF
--- a/app/src/androidTest/java/com/acetylsalicylsaeure/platten/WeightProgressChartTest.kt
+++ b/app/src/androidTest/java/com/acetylsalicylsaeure/platten/WeightProgressChartTest.kt
@@ -1,0 +1,119 @@
+package com.acetylsalicylsaeure.platten.ui.components
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import junit.framework.TestCase.assertEquals
+import junit.framework.TestCase.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Calendar
+import java.util.Date
+
+@RunWith(AndroidJUnit4::class)
+class WeightProgressChartTest {
+
+    private lateinit var testLogs: List<Quadruple<Int, Float, Int, Date>>
+
+    private fun createDate(daysAgo: Int): Date {
+        val calendar = Calendar.getInstance()
+        calendar.add(Calendar.DAY_OF_YEAR, -daysAgo)
+        return calendar.time
+    }
+
+    @Before
+    fun setup() {
+        // Create test data deliberately out of chronological order
+        testLogs = listOf(
+            Quadruple(1, 100f, 5, createDate(3)),   // 3 days ago
+            Quadruple(1, 102.5f, 5, createDate(1)), // yesterday
+            Quadruple(1, 97.5f, 5, createDate(4)),  // 4 days ago
+            Quadruple(1, 105f, 5, createDate(0)),   // today
+            Quadruple(1, 100f, 5, createDate(2))    // 2 days ago
+        )
+    }
+
+    @Test
+    fun testDateBasedSorting() {
+        // Sort logs by date
+        val sortedLogs = testLogs.sortedBy { it.fourth }
+
+        // Verify logs are in chronological order
+        for (i in 0 until sortedLogs.size - 1) {
+            assertTrue(
+                "Each log should be from an earlier or same date as the next log",
+                sortedLogs[i].fourth.time <= sortedLogs[i + 1].fourth.time
+            )
+        }
+
+        // Verify the weights are in the expected chronological order after sorting
+        val expectedWeights = listOf(97.5f, 100f, 100f, 102.5f, 105f)
+        val actualWeights = sortedLogs.map { it.second }
+        assertEquals(
+            "Weights should be in chronological order after date sorting",
+            expectedWeights,
+            actualWeights
+        )
+    }
+
+    @Test
+    fun testViewWindowWithDateOrder() {
+        val viewWindow = 3
+        val sortedLogs = testLogs.sortedBy { it.fourth }
+        val filteredLogs = if (viewWindow > 0 && viewWindow < sortedLogs.size) {
+            sortedLogs.takeLast(viewWindow)
+        } else {
+            sortedLogs
+        }
+
+        // Verify we get the most recent logs
+        assertEquals("Should return exactly viewWindow logs", viewWindow, filteredLogs.size)
+
+        // Verify the filtered logs are the most recent ones in correct order
+        val expectedWeights = listOf(100f, 102.5f, 105f)  // Most recent 3 weights
+        val actualWeights = filteredLogs.map { it.second }
+        assertEquals(
+            "Filtered weights should be the most recent ones in chronological order",
+            expectedWeights,
+            actualWeights
+        )
+
+        // Verify the dates are still in order
+        for (i in 0 until filteredLogs.size - 1) {
+            assertTrue(
+                "Filtered logs should maintain chronological order",
+                filteredLogs[i].fourth.time <= filteredLogs[i + 1].fourth.time
+            )
+        }
+    }
+
+    @Test
+    fun testModifiedDatesHandling() {
+        // Create logs with deliberately modified dates
+        val logsWithModifiedDates = listOf(
+            Quadruple(1, 100f, 5, createDate(5)),  // Original log
+            Quadruple(1, 102.5f, 5, createDate(2)), // Modified to be earlier
+            Quadruple(1, 105f, 5, createDate(3))   // Modified to be in between
+        )
+
+        val sortedLogs = logsWithModifiedDates.sortedBy { it.fourth }
+
+        // Verify correct ordering regardless of modification order
+        // Dates are: 2 days ago (102.5f), 3 days ago (105f), 5 days ago (100f)
+        val expectedWeights = listOf(100f, 105f, 102.5f)
+        val actualWeights = sortedLogs.map { it.second }
+        assertEquals(
+            "Logs should be ordered by date regardless of modification history",
+            expectedWeights,
+            actualWeights
+        )
+
+        // Verify chronological ordering
+        for (i in 0 until sortedLogs.size - 1) {
+            assertTrue(
+                "Modified dates should still maintain chronological order",
+                sortedLogs[i].fourth.time <= sortedLogs[i + 1].fourth.time
+            )
+        }
+    }
+}

--- a/app/src/main/java/com/acetylsalicylsaeure/platten/ui/components/WeightProgressChart.kt
+++ b/app/src/main/java/com/acetylsalicylsaeure/platten/ui/components/WeightProgressChart.kt
@@ -20,11 +20,14 @@ import com.github.mikephil.charting.data.ScatterDataSet
 import com.github.mikephil.charting.charts.CombinedChart;
 import com.github.mikephil.charting.data.CombinedData;
 import com.github.mikephil.charting.data.LineData
+import java.util.Date
 import kotlin.math.roundToInt
+
+data class Quadruple<A, B, C, D>(val first: A, val second: B, val third: C, val fourth: D)
 
 @Composable
 fun WeightProgressChart(
-    logs: List<Triple<Int, Float, Int>>,
+    logs: List<Quadruple<Int, Float, Int, Date>>,
     viewWindow: Int,
     regression: Triple<Double, Double, Double>?,
     fitToLastSession: Boolean
@@ -32,6 +35,12 @@ fun WeightProgressChart(
     val primaryColor = MaterialTheme.colorScheme.primary.toArgb()
     val secondaryColor = MaterialTheme.colorScheme.secondary.toArgb()
     val textColor = MaterialTheme.colorScheme.onSurface.toArgb()
+    val sortedLogs = logs.sortedBy { it.fourth }  // Sort by date
+    val filteredLogs = if (viewWindow > 0 && viewWindow < sortedLogs.size) {
+        sortedLogs.takeLast(viewWindow)
+    } else {
+        sortedLogs
+    }
 
     Box(modifier = Modifier.fillMaxSize()) {
         AndroidView(
@@ -66,13 +75,7 @@ fun WeightProgressChart(
                 }
             },
             update = { chart ->
-                val filteredLogs = if (viewWindow > 0 && viewWindow < logs.size) {
-                    logs.takeLast(viewWindow)
-                } else {
-                    logs
-                }
-
-                val entries = filteredLogs.mapIndexed { index, (_, weight, reps) ->
+                val entries = filteredLogs.mapIndexed { index, (_, weight, reps, _) ->
                     val estimatedOneRM = calculateEstimatedOneRM(weight, reps)
                     Entry(index.toFloat(), estimatedOneRM)
                 }

--- a/app/src/main/java/com/acetylsalicylsaeure/platten/ui/screens/ExerciseDetailScreen.kt
+++ b/app/src/main/java/com/acetylsalicylsaeure/platten/ui/screens/ExerciseDetailScreen.kt
@@ -22,6 +22,7 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import com.acetylsalicylsaeure.platten.data.ExerciseLog
 import com.acetylsalicylsaeure.platten.data.Preferences
+import com.acetylsalicylsaeure.platten.ui.components.Quadruple
 import com.acetylsalicylsaeure.platten.ui.components.WeightProgressChart
 import com.acetylsalicylsaeure.platten.ui.components.adjustWeightForReps
 import com.acetylsalicylsaeure.platten.ui.components.roundToNearestWeightStep
@@ -202,7 +203,7 @@ fun ExerciseDetailScreen(
                             .padding(vertical = 8.dp)
                     ) {
                         WeightProgressChart(
-                            logs = logs.value.map { Triple(it.exerciseId, it.weight, it.reps) },
+                            logs = logs.value.map { Quadruple(it.exerciseId, it.weight, it.reps, it.date) },
                             viewWindow = viewWindow,
                             regression = regression,
                             fitToLastSession = fitToLastSession

--- a/app/src/main/java/com/acetylsalicylsaeure/platten/viewmodel/ExerciseViewModel.kt
+++ b/app/src/main/java/com/acetylsalicylsaeure/platten/viewmodel/ExerciseViewModel.kt
@@ -143,10 +143,13 @@ class ExerciseViewModel(application: Application) : AndroidViewModel(application
     ): Triple<Double, Double, Double>? {
         if (logs.isEmpty()) return null
 
+        // First sort logs by date
+        val sortedLogs = logs.sortedBy { it.date }
+
         val filteredLogs = if (regressionWindow > 0) {
-            logs.takeLast(regressionWindow)
+            sortedLogs.takeLast(regressionWindow)
         } else {
-            logs
+            sortedLogs
         }
 
         val n = filteredLogs.size


### PR DESCRIPTION
This commit introduces date-based sorting and filtering to the weight progress chart logs. The chart now sorts the logs by date before displaying them. It also includes unit tests to ensure the sorting and filtering logic works correctly, especially when dealing with potentially out-of-order or modified log entries.
- Sort logs by date
- Add a Quadruple data class for the logs
- Filter logs by date, based on the viewWindow parameter
- Add unit tests for the sorting and filtering logic